### PR TITLE
Added version number to request

### DIFF
--- a/Blitline.Net/Request/BlitlineRequest.cs
+++ b/Blitline.Net/Request/BlitlineRequest.cs
@@ -33,6 +33,8 @@ namespace Blitline.Net.Request
 		public bool IncludeIptc { get; set; }
 		[JsonProperty ("get_exif")]
 		public bool GetExif { get; set; }
+		[JsonProperty("v")]
+	        public double Version { get; set; }
 
         /// <summary>
         /// Blitline returns an image url such as http://s3.amazonaws.com/gdoubleu-test-photos/annotate-default.png

--- a/Blitline.Net/Request/Builders/RequestBuilder.cs
+++ b/Blitline.Net/Request/Builders/RequestBuilder.cs
@@ -60,6 +60,12 @@ namespace Blitline.Net.Request.Builders
             _request.Hash = hash;
             return this;
         }
+        
+        public RequestBuilder WithVersion(double version)
+        {
+            _request.Version = version;
+            return this;
+        }
 
 		public RequestBuilder GetExif ()
 		{


### PR DESCRIPTION
I was having problems with a JSON response from Blitline not returning proper JSON and it turned out to be due to an out-of-date service. Specifying a version number corrects this problem and should make the library more future proof. I've added a version property to the request and method to the request builder. Not sure why github has edited so many lines, possibly because I did it all through the browser. Might be worth a quick once over but hopefully it's helpful.

I've had to make a bunch more changes locally to allow support for Blitline's newer IAM-based security but if I submitted these as-is they would break previous versions. It might be easier to share the code or when I get a bit further I may be able to come up with a backwardly compatible approach. Let me know if that would be of interest.